### PR TITLE
Reduce mid-walk jittering, and ensure first step happens

### DIFF
--- a/walk/include/walk/walk.hpp
+++ b/walk/include/walk/walk.hpp
@@ -68,6 +68,7 @@ private:
   void walk(const geometry_msgs::msg::Twist & commanded_twist);
   void notifyPhase(const biped_interfaces::msg::Phase & phase);
   void imuCallback(const sensor_msgs::msg::Imu & imu);
+  void calculateNewStep(const biped_interfaces::msg::Phase& phase);
   void generateCommand();
   void phaseCallback(const biped_interfaces::msg::Phase::SharedPtr msg);
   void targetCallback(const geometry_msgs::msg::Twist::SharedPtr msg);

--- a/walk/include/walk/walk.hpp
+++ b/walk/include/walk/walk.hpp
@@ -77,7 +77,6 @@ private:
 
   // State variables
   biped_interfaces::msg::Phase phase_;
-  walk_interfaces::msg::FeetTrajectoryPoint ftp_current_;
   geometry_msgs::msg::Twist curr_twist_;
   float filtered_gyro_y_ = 0.0;
 

--- a/walk/src/step_state.cpp
+++ b/walk/src/step_state.cpp
@@ -23,6 +23,10 @@ bool StepState::done()
 {
   return i >= (step.points.size() - 1);
 }
+
+double StepState::progressRatio()
+{
+  return static_cast<double>(i) / (step.points.size() - 1);
 }
 
 const walk_interfaces::msg::FeetTrajectoryPoint & StepState::next()

--- a/walk/src/step_state.cpp
+++ b/walk/src/step_state.cpp
@@ -21,10 +21,16 @@ StepState::StepState(const walk_interfaces::msg::Step & step)
 
 bool StepState::done()
 {
-  return i == step.points.size();
+  return i >= (step.points.size() - 1);
+}
 }
 
 const walk_interfaces::msg::FeetTrajectoryPoint & StepState::next()
 {
-  return step.points.at(i++);
+  return step.points.at(++i);
+}
+
+const walk_interfaces::msg::FeetTrajectoryPoint & StepState::current()
+{
+  return step.points.at(i);
 }

--- a/walk/src/step_state.hpp
+++ b/walk/src/step_state.hpp
@@ -23,6 +23,7 @@ public:
   explicit StepState(const walk_interfaces::msg::Step & step);
   bool done();
   const walk_interfaces::msg::FeetTrajectoryPoint & next();
+  const walk_interfaces::msg::FeetTrajectoryPoint & current();
 
 private:
   const walk_interfaces::msg::Step step;

--- a/walk/src/step_state.hpp
+++ b/walk/src/step_state.hpp
@@ -22,6 +22,7 @@ class StepState
 public:
   explicit StepState(const walk_interfaces::msg::Step & step);
   bool done();
+  double progressRatio();
   const walk_interfaces::msg::FeetTrajectoryPoint & next();
   const walk_interfaces::msg::FeetTrajectoryPoint & current();
 

--- a/walk/src/walk.cpp
+++ b/walk/src/walk.cpp
@@ -128,13 +128,13 @@ void Walk::notifyPhase(const biped_interfaces::msg::Phase & phase)
     get_logger(), "Using %s",
     (phase.phase == phase.LEFT_STANCE) ? "LSP (Left Stance Phase)" : "RSP (Right Stance Phase)");
 
+  auto ftp_current =
+    step_state_ ? step_state_->current() : walk_interfaces::msg::FeetTrajectoryPoint{};
   step_ = std::make_unique<walk_interfaces::msg::Step>(
     feet_trajectory::generate(
-      params_->feet_trajectory_, phase, ftp_current_, ftp_next));
+      params_->feet_trajectory_, phase, ftp_current, ftp_next));
   step_state_ = std::make_unique<StepState>(*step_);
   pub_step_->publish(*step_);
-
-  ftp_current_ = std::move(ftp_next);
 }
 
 void Walk::imuCallback(const sensor_msgs::msg::Imu & imu)

--- a/walk/src/walk.cpp
+++ b/walk/src/walk.cpp
@@ -100,6 +100,14 @@ void Walk::walk(const geometry_msgs::msg::Twist & commanded_twist)
     commanded_twist.angular.x, commanded_twist.angular.y, commanded_twist.angular.z);
 
   target_twist_ = twist_limiter::limit(params_->twist_limiter_, commanded_twist);
+
+  if (!step_)
+  {
+    RCLCPP_DEBUG(get_logger(), "Calculating first step!");
+    biped_interfaces::msg::Phase phase;
+    phase.phase = phase.RIGHT_SWING;
+    calculateNewStep(phase);
+  }
 }
 
 void Walk::notifyPhase(const biped_interfaces::msg::Phase & phase)
@@ -117,6 +125,11 @@ void Walk::notifyPhase(const biped_interfaces::msg::Phase & phase)
     return;
   }
 
+  calculateNewStep(phase);
+}
+
+void Walk::calculateNewStep(const biped_interfaces::msg::Phase& phase)
+{
   RCLCPP_DEBUG(get_logger(), "Calculating new step!");
 
   phase_ = phase;

--- a/walk/src/walk.cpp
+++ b/walk/src/walk.cpp
@@ -111,6 +111,12 @@ void Walk::notifyPhase(const biped_interfaces::msg::Phase & phase)
     return;
   }
 
+  if (step_state_ && step_state_->progressRatio() < 0.5) {
+    RCLCPP_DEBUG(get_logger(),
+        "Notified of a phase change, but the step is still in its early stages. Ignoring.");
+    return;
+  }
+
   RCLCPP_DEBUG(get_logger(), "Calculating new step!");
 
   phase_ = phase;


### PR DESCRIPTION
I've tested the walk in webots after observing the jittery behavior at 0:25 and 0:36 in the youtube short that @Josh posted.

I think there are two issues causing the jitter there.

1. Rapid phase switching - nothing is filtering the noise coming in from phase switching (reported from the feet pressure sensors). It is possible that rapid switching between phases can happen, and the old runswift walk prevented this by ignoring rapid phase switching. I added the same logic to the walk, and I don't see rapid phase switching.  The diagram below shows the height of right foot sole, where you can see short spikes, where this rapid switching happens.

![image](https://github.com/user-attachments/assets/3d7118f2-d0c5-490f-a50d-ef55d00c4ee5)

2. Incorrect interpolation of the next step. Interpolation for a new step did not consider where the last step finished. If the step did not finish, it still interpolated from the "ideal" finishing position of the previous step. The diagram below shows how large jumps were happening in the feet trajectory. I've added some changes to fix this.

![image](https://github.com/user-attachments/assets/952c2330-729d-4ae9-b9fc-ff1ce8e4b261)

---

In addition, upon the first target message reeived, force a new step to be calculated such that the walk is initiated. Otherwise, a gentle "push" of the robot is required to trigger a phase change currently.